### PR TITLE
Upgrade node from 8 to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ FROM ubuntu:18.04
 
 ADD bazel_loader bazel_loader
 RUN apt-get update && \
-      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libgmp-dev libreadline-dev libssl-dev libtinfo-dev libxml2 make moreutils nodejs openssh-client patch pkg-config python ruby rubygems shellcheck software-properties-common unzip wget xxd zip zlib1g-dev && \
+      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libgmp-dev libreadline-dev libssl-dev libtinfo-dev libxml2 make moreutils openssh-client patch pkg-config python ruby rubygems shellcheck software-properties-common unzip wget xxd zip zlib1g-dev && \
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+      echo "deb https://deb.nodesource.com/node_14.x bionic main" | tee /etc/apt/sources.list.d/nodesource.list && \
+      echo "deb-src https://deb.nodesource.com/node_14.x bionic main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
       curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
       echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
       curl -sS https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
       echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | tee /etc/apt/sources.list.d/llvm.list && \
       apt-get update && \
-      apt-get install --no-install-recommends -y yarn clang-9 && \
+      apt-get install --no-install-recommends -y nodejs yarn clang-9 && \
       cd bazel_loader && \
       ./bazel version && \
       rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This image uses the Ubuntu supplied version of Node, which is v8. 

The upgraded dependencies for the Sorbet website in https://github.com/sorbet/sorbet/pull/4197 require a newer version of node when running the linter test. 

This PR switches to using the nodesource binary releases and upgrades to the current LTS version 14. 