### PR TITLE
Update sorbet-build-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Useful debugging commands / Docker cheatsheet:
 #
-#   # Interactive shell inside a container:
-#   docker run --rm -it --platform linux/arm64 ubuntu:20.04 bash
+#     # Interactive shell inside a container:
+#     docker run --rm -it ubuntu:20.04 bash
 #
-#   # Flags that make building respect the host's HTTP proxy settings
-#   --network host --build-arg http_proxy="$http_proxy" --build-arg https_proxy="$https_proxy" --build-arg no_proxy="$no_proxy"
+#     # Flags that make building respect the host's HTTP proxy settings
+#     --network host --build-arg http_proxy="$http_proxy" --build-arg https_proxy="$https_proxy" --build-arg no_proxy="$no_proxy"
 
-ADD bazel_loader bazel_loader
 RUN apt-get update && \
-      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libgmp-dev libreadline-dev libffi-dev libssl-dev libtinfo-dev libxml2 libyaml-dev make moreutils openssh-client patch pkg-config python ruby rubygems software-properties-common unzip wget xxd xz-utils zip zlib1g-dev libtinfo5
+      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libasound2 libatk-bridge2.0-0 libatk1.0-0 libdrm2 libffi-dev libgbm1 libgdk-pixbuf2.0-0 libgmp-dev libgtk-3-0 libnss3-dev libreadline-dev libssl-dev libtinfo-dev libtinfo5 libxml2 libxshmfence-dev libyaml-dev make moreutils openssh-client patch pkg-config python ruby rubygems software-properties-common unzip wget xvfb xxd xz-utils zip zlib1g-dev
 RUN mkdir -p /usr/share/keyrings /etc/apt/keyrings && \
       curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
@@ -23,8 +22,6 @@ RUN mkdir -p /usr/share/keyrings /etc/apt/keyrings && \
       echo "deb [signed-by=/etc/apt/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
       apt-get update && \
       apt-get install --no-install-recommends -y nodejs yarn && \
-      cd bazel_loader && \
-      ./bazel version && \
       rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSOL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.linux.$(arch).tar.xz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,25 @@
 FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Useful debugging commands / Docker cheatsheet:
+#
+#   # Interactive shell inside a container:
+#   docker run --rm -it --platform linux/arm64 ubuntu:20.04 bash
+#
+#   # Flags that make building respect the host's HTTP proxy settings
+#   --network host --build-arg http_proxy="$http_proxy" --build-arg https_proxy="$https_proxy" --build-arg no_proxy="$no_proxy"
+
 ADD bazel_loader bazel_loader
-# Install libstdc++6 from ppa:ubuntu-toolchain-r/test to get GLIBCXX_3.4.26
-# Unfortunately 18.04 repositories only provide GLIBCXX_3.4.25
 RUN apt-get update && \
-      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libgmp-dev libreadline-dev libffi-dev libssl-dev libtinfo-dev libxml2 libyaml-dev make moreutils openssh-client patch pkg-config python ruby rubygems software-properties-common unzip wget xxd xz-utils zip zlib1g-dev libtinfo5 && \
-      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-      echo "deb https://deb.nodesource.com/node_14.x bionic main" | tee /etc/apt/sources.list.d/nodesource.list && \
-      echo "deb-src https://deb.nodesource.com/node_14.x bionic main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
-      curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-      echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-      curl -sS https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-      echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | tee /etc/apt/sources.list.d/llvm.list && \
+      apt-get install --no-install-recommends -y autoconf ca-certificates curl debconf-utils file g++ git gpg-agent jq libgmp-dev libreadline-dev libffi-dev libssl-dev libtinfo-dev libxml2 libyaml-dev make moreutils openssh-client patch pkg-config python ruby rubygems software-properties-common unzip wget xxd xz-utils zip zlib1g-dev libtinfo5
+RUN mkdir -p /usr/share/keyrings /etc/apt/keyrings && \
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+      echo "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee -a /etc/apt/sources.list.d/nodesource.list && \
+      curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn-archive-keyring.gpg && \
+      echo "deb [signed-by=/etc/apt/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
       apt-get update && \
-      apt-get install --no-install-recommends -y nodejs yarn clang-9 && \
-      add-apt-repository --yes ppa:ubuntu-toolchain-r/test && \
-      apt-get update && \
-      apt-get install --yes --only-upgrade libstdc++6 && \
+      apt-get install --no-install-recommends -y nodejs yarn && \
       cd bazel_loader && \
       ./bazel version && \
       rm -rf /var/lib/apt/lists/*
@@ -36,10 +38,10 @@ ENV PATH=/root/.rbenv/bin:/root/.rbenv/shims:$PATH
 RUN curl -fsSL https://raw.githubusercontent.com/rbenv/rbenv-installer/108c12307621a0aa06f19799641848dde1987deb/bin/rbenv-installer | bash -x
 RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
 RUN echo 'eval "$(rbenv init -)"' >> /root/.bashrc
-RUN rbenv install 3.1.2
-RUN rbenv install 3.3.0
-RUN rbenv install 3.4.5
-RUN rbenv global 3.1.2
+RUN rbenv install 3.3.12
+RUN rbenv install 3.4.9
+RUN rbenv install 4.0.6
+RUN rbenv global 3.3.12
 
 ENV TINI_VERSION v0.18.0
 RUN curl -fsSL -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture)


### PR DESCRIPTION
- Upgrade installed Rubies (3.3, 3.4, 4.0, drop 3.1)
- Upgrade node 14 -> 16 (apt signing key nonsense)
- Drop clang-9 (unused)
- Move the vscode-extension test packages into the image (`xvfb-run`)
- Drop the GLIBC/libstdc++6 stuff, seems like it was an ubuntu 18.04 hack

Also, I'm moving to publish this to the Stripe Docker Hub account, because the
email account we created to use for signing into our `sorbetruby` Docker Hub
account is an `@stripe.com` email, which means that SSO is required, and I'm not
sure how to SSO from that email list.

Instead, we're now going to be "members" of the `stripe` Docker Hub account,
which should be the same in practice. There are docs on how this works
internally at <http://go/types/sorbet-build-image>.